### PR TITLE
マークダウン用gem追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,8 @@ gem 'kaminari'
 gem 'devise'
 gem 'devise-i18n'
 gem 'devise-i18n-views'
-gem "aws-sdk-s3", require: false
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console


### PR DESCRIPTION
マークダウン記法で記事作成できるようにするため、
gem 'redcarpet', '~> 2.3.0'
gem 'coderay'
を追加